### PR TITLE
Add UIDPLUS capability on copyMessages

### DIFF
--- a/src/java/com/icegreen/greenmail/imap/ImapConstants.java
+++ b/src/java/com/icegreen/greenmail/imap/ImapConstants.java
@@ -16,7 +16,7 @@ public interface ImapConstants {
 
     String SP = " ";
     String VERSION = "IMAP4rev1";
-    String CAPABILITIES = "LITERAL+";
+    String CAPABILITIES = "LITERAL+ UIDPLUS";
 
     String USER_NAMESPACE = "#mail";
 

--- a/src/java/com/icegreen/greenmail/imap/ImapResponse.java
+++ b/src/java/com/icegreen/greenmail/imap/ImapResponse.java
@@ -188,6 +188,14 @@ public class ImapResponse implements ImapConstants {
         end();
     }
 
+    public void taggedResponseCompleted(String message) {
+    	tag();
+        message(OK);
+        message(message);
+        message("completed.");
+        end();
+    }
+    
     /**
      * Writes the message provided to the client, prepended with the
      * untagged marker "*".

--- a/src/java/com/icegreen/greenmail/imap/ImapSessionFolder.java
+++ b/src/java/com/icegreen/greenmail/imap/ImapSessionFolder.java
@@ -203,8 +203,8 @@ public class ImapSessionFolder implements MailFolder, FolderListener {
         return _folder.search(searchTerm);
     }
 
-    public void copyMessage(long uid, MailFolder toFolder) throws FolderException {
-        _folder.copyMessage(uid, toFolder);
+    public long copyMessage(long uid, MailFolder toFolder) throws FolderException {
+        return _folder.copyMessage(uid, toFolder);
     }
 
     public void addListener(FolderListener listener) {

--- a/src/java/com/icegreen/greenmail/imap/commands/CopyCommand.java
+++ b/src/java/com/icegreen/greenmail/imap/commands/CopyCommand.java
@@ -78,14 +78,16 @@ class CopyCommand extends SelectedStateCommand implements UidEnabledCommand {
             }
         }
         
-        String copyUidResponse = buildCOPYUIDResponse(uidsOfCopiedAndNewMessages);
+        String copyUidResponse = buildCOPYUIDResponse(uidsOfCopiedAndNewMessages, currentMailbox.getUidValidity());
         session.unsolicitedResponses(response);
         response.taggedResponseCompleted(copyUidResponse);
     }
 
-    private String buildCOPYUIDResponse(Map uidsOfCopiedAndNewMessages) {
+    private String buildCOPYUIDResponse(Map uidsOfCopiedAndNewMessages, long mailboxUidValidity) {
     	String UID_SEPARATOR = " ";
-    	StringBuilder builder = new StringBuilder("[COPYUID 9999999");
+    	StringBuilder builder = new StringBuilder("[COPYUID ");
+    	builder.append(mailboxUidValidity);
+    	
     	Iterator uidsIterator = uidsOfCopiedAndNewMessages.entrySet().iterator();
 		while (uidsIterator.hasNext()) {
 			Entry uids = (Entry) uidsIterator.next();

--- a/src/java/com/icegreen/greenmail/store/InMemoryStore.java
+++ b/src/java/com/icegreen/greenmail/store/InMemoryStore.java
@@ -463,7 +463,7 @@ public class InMemoryStore
             return matchedUids;
         }
 
-        public void copyMessage(long uid, MailFolder toFolder)
+        public long copyMessage(long uid, MailFolder toFolder)
                 throws FolderException {
             SimpleStoredMessage originalMessage = getMessage(uid);
             MimeMessage newMime = null;
@@ -477,7 +477,7 @@ public class InMemoryStore
             newFlags.add(originalMessage.getFlags());
             Date newDate = originalMessage.getInternalDate();
 
-            toFolder.appendMessage(newMime, newFlags, newDate);
+            return toFolder.appendMessage(newMime, newFlags, newDate);
         }
 
         public void expunge() throws FolderException {

--- a/src/java/com/icegreen/greenmail/store/MailFolder.java
+++ b/src/java/com/icegreen/greenmail/store/MailFolder.java
@@ -66,7 +66,7 @@ public interface MailFolder {
 
     long[] search(SearchTerm searchTerm);
 
-    void copyMessage(long uid, MailFolder toFolder)
+    long copyMessage(long uid, MailFolder toFolder)
             throws FolderException;
 
     void setFlags(Flags flags, boolean value, long uid, FolderListener silentListener, boolean addUid) throws FolderException;


### PR DESCRIPTION
This patch make Greenmail supporting the UIDPLUS functionality for the IMAP command "UID COPY".
