### PR TITLE
Fixed expunge method

### DIFF
--- a/src/main/java/com/icegreen/greenmail/store/InMemoryStore.java
+++ b/src/main/java/com/icegreen/greenmail/store/InMemoryStore.java
@@ -433,7 +433,7 @@ public class InMemoryStore
             appendMessage(message, flags, internalDate);
         }
 
-        
+
         public SimpleStoredMessage getMessage(long uid) {
             for (int i = 0; i < mailMessages.size(); i++) {
                 SimpleStoredMessage message = mailMessages.get(i);
@@ -494,7 +494,7 @@ public class InMemoryStore
         }
 
         public void expunge() throws FolderException {
-            for (int i = 0; i < mailMessages.size(); i++) {
+            for (int i = mailMessages.size() - 1; i >= 0; i--) {
                 SimpleStoredMessage message = mailMessages.get(i);
                 if (message.getFlags().contains(Flags.Flag.DELETED)) {
                     expungeMessage(i + 1);

--- a/src/test/java/com/icegreen/greenmail/Pop3ServerTest.java
+++ b/src/test/java/com/icegreen/greenmail/Pop3ServerTest.java
@@ -60,6 +60,36 @@ public class Pop3ServerTest {
     }
 
     @Test
+    public void testImapExpunge() throws Exception {
+        greenMail = new GreenMail(ServerSetupTest.SMTP_IMAP);
+        assertNotNull(greenMail.getImap());
+        greenMail.start();
+        final String subject = GreenMailUtil.random();
+        final String body = GreenMailUtil.random() + "\r\n" + GreenMailUtil.random() + "\r\n" + GreenMailUtil.random();
+        String to = "test@localhost.com";
+        GreenMailUtil.sendTextEmailTest(to, "from@localhost.com", subject, body);
+        greenMail.waitForIncomingEmail(5000, 1);
+        GreenMailUtil.sendTextEmailTest(to, "from@localhost.com", subject, body);
+        greenMail.waitForIncomingEmail(5000, 1);
+        GreenMailUtil.sendTextEmailTest(to, "from@localhost.com", subject, body);
+        greenMail.waitForIncomingEmail(5000, 1);
+        GreenMailUtil.sendTextEmailTest(to, "from@localhost.com", subject, body);
+        greenMail.waitForIncomingEmail(5000, 1);
+
+        Retriever retriever = new Retriever(greenMail.getImap());
+        Message[] messages = retriever.getMessages(to);
+        assertEquals(4, messages.length);
+        for (Message message : messages) {
+        	message.setFlag(javax.mail.Flags.Flag.DELETED, true);
+        }
+        retriever.logoutAndExpunge();
+        retriever = new Retriever(greenMail.getImap());
+        messages = retriever.getMessages(to);
+        assertEquals(0, messages.length);
+    }
+
+
+    @Test
     public void testPop3sReceive() throws Throwable {
         greenMail = new GreenMail(new ServerSetup[]{ServerSetupTest.SMTPS, ServerSetupTest.POP3S});
         assertNull(greenMail.getPop3());


### PR DESCRIPTION
I've fixed the expunge method so that it now deletes multiple messages correctly.

Previously it would only delete half the flagged messages. The problem was that it traversed a list of messages in ascending order, while modifying it.
